### PR TITLE
Updates react native testing library import

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Effect:
 
 ```javascript
 import React from 'react';
-import { render } from 'react-native-testing-library';
+import { render } from '@testing-library/react-native';
 
 import { Search } from '../example/Search.tsx';
 

--- a/template/template
+++ b/template/template
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from 'react-native-testing-library';
+import { render } from '@testing-library/react-native';
 
 import { <%= componentName %> } from '<%= filepath %>';
 


### PR DESCRIPTION
Changed 'react-native-testing-library' to '@testing-library/react-native' due to [deprecation of the 'react-native-testing-library'.](https://www.npmjs.com/package/react-native-testing-library)